### PR TITLE
Compilation under MSVC

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <cstring>
-#include <unistd.h>
+#include <string>
 #include <windows.h>
 #include <fstream>
 #include <windows.h>


### PR DESCRIPTION
The current main.cpp included unistd.h, which isn't supported by MSVC compiler (tried on  Version 19.28.29334 )

The sole functions in use from unistd.h were two `getline` statements, replacing them with the getline overloads defined in `<string>` 🙂 - 

https://en.cppreference.com/w/cpp/string/basic_string/getline

![image](https://user-images.githubusercontent.com/37269665/114571922-aa3ab880-9c94-11eb-9d75-daf77b9ff04e.png)
